### PR TITLE
Adds single payee support with multiple line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Adds initial support for Craft Commerce Pro and multiple line items, when all line items have the same payee
+
 ## v1.1.0 - 2021-01-16
 
 - Adds `PayeesServices` [and initial developer events](https://github.com/kennethormandy/craft-marketplace/tree/ko-payees-service#events), with `EVENT_BEFORE_DETERMINE_PAYEE` and `EVENT_AFTER_DETERMINE_PAYEE`, [#12](https://github.com/kennethormandy/craft-marketplace/issues/12)

--- a/src/Marketplace.php
+++ b/src/Marketplace.php
@@ -374,7 +374,7 @@ class Marketplace extends BasePlugin
                       $lineItemPayees = [];
                       foreach ($order->lineItems as $key => $lineItem) {
                         if ($key > 0) {
-                          $payeeCurrent = $this->payees->getGatewayAccountId($lineItemOnly)
+                          $payeeCurrent = $this->payees->getGatewayAccountId($lineItemOnly);
                           if ($payeeCurrent != $payeeStripeAccountId) {
                             $payeesSame = false;
                             return;

--- a/src/Marketplace.php
+++ b/src/Marketplace.php
@@ -351,7 +351,7 @@ class Marketplace extends BasePlugin
 
                     if (!$payeeStripeAccountId) {
                         Craft::info(
-                            '[Marketplace] Stripe ' . $hardCodedApproach . ' no User Payee Account ID. Paying to parent account.',
+                            '[Marketplace] [Order #' . $order->id . '] Stripe ' . $hardCodedApproach . ' no User Payee Account ID. Paying to parent account.',
                             __METHOD__
                         );
         

--- a/src/Marketplace.php
+++ b/src/Marketplace.php
@@ -374,7 +374,7 @@ class Marketplace extends BasePlugin
                       $lineItemPayees = [];
                       foreach ($order->lineItems as $key => $lineItem) {
                         if ($key > 0) {
-                          $payeeCurrent = $this->payees->getGatewayAccountId($lineItemOnly);
+                          $payeeCurrent = $this->payees->getGatewayAccountId($lineItem);
                           if ($payeeCurrent != $payeeStripeAccountId) {
                             $payeesSame = false;
                             return;

--- a/src/services/PayeesService.php
+++ b/src/services/PayeesService.php
@@ -54,7 +54,7 @@ class PayeesService extends Component
           $purchasablePayeeUser = User::find()->id($payeeUserId)->one();
       } else {
           Craft::info(
-              '[Marketplace] Stripe ' . $hardCodedApproach . ' no User Payee configured, paying to parent account.',
+              '[Marketplace] [PayeesService] No User Payee Account ID.',
               __METHOD__
           );
 

--- a/src/services/PayeesService.php
+++ b/src/services/PayeesService.php
@@ -57,10 +57,10 @@ class PayeesService extends Component
               '[Marketplace] [PayeesService] No User Payee Account ID.',
               __METHOD__
           );
-
-          return;
+        
+          return null;
       }
-      
+
       $stripeConnectHandle = Marketplace::$plugin->handlesService->getButtonHandle($purchasablePayeeUser);
       $payeeStripeAccountId = $purchasablePayeeUser[$stripeConnectHandle];
       

--- a/src/services/PayeesService.php
+++ b/src/services/PayeesService.php
@@ -30,7 +30,12 @@ class PayeesService extends Component
       }
 
       $payeeHandle = Marketplace::$plugin->handlesService->getPayeeHandle();
-      if (isset($purchasable[$payeeHandle]) && $purchasable[$payeeHandle] !== null) {
+      
+      if (
+          isset($purchasable[$payeeHandle]) && 
+          $purchasable[$payeeHandle] !== null &&
+          $purchasable[$payeeHandle]
+      ) {
           if (is_numeric($purchasable[$payeeHandle])) {
             // Craft Commerce v3 Digital Products
             $payeeUserId = $purchasable[$payeeHandle];
@@ -39,8 +44,12 @@ class PayeesService extends Component
             // Craft Commerce v2 Digital Products?
             $purchasablePayeeUser = $purchasable[$payeeHandle]->one();
           }
-      } elseif (isset($purchasable->product[$payeeHandle]) && $purchasable->product[$payeeHandle] !== null) {
-          // All other products
+      } elseif (
+          isset($purchasable->product[$payeeHandle]) &&
+          $purchasable->product[$payeeHandle] !== null &&
+          $purchasable->product[$payeeHandle]
+      ) {
+          // Typcial products
           $payeeUserId = $purchasable->product[$payeeHandle];
           $purchasablePayeeUser = User::find()->id($payeeUserId)->one();
       } else {

--- a/tests/acceptance/ViewBuyCest.php
+++ b/tests/acceptance/ViewBuyCest.php
@@ -12,11 +12,11 @@ class ViewBuyCest
         $I->see('Buy your hand-crafted');
         $I->click('a.bg-blue-commerce');
         // $I->see('Adding');
-        
+
         // The form is auto-submitted via JS, which we don’t have
         // in the PHP browser, so we submit the form ourselves
         // $I->click('.add-to-cart-form input[type="submit"]');
-        
+
         // /buy?step=2
         $I->see('Your Address');
         $I->fillField('#firstName', 'Jane');
@@ -27,16 +27,16 @@ class ViewBuyCest
         $I->fillField('#zipCode', 'Example');
         $I->fillField('#stateValue', 'EX');
         $I->click('Next');
-        
+
         // /buy?step=1
         $I->see('Your Email');
         $I->fillField('#email', 'hi@example.com');
         $I->click('Next');
-        
+
         // /buy?step=2
         $I->see('Your Address');
         $I->click('Next');
-        
+
         // /buy?step=3
         $I->see('Your Payment Information');
 
@@ -57,10 +57,10 @@ class ViewBuyCest
 
         // Exit iframe
         $I->switchToIFrame();
-        
+
         $I->see('Buy $60');
         $I->click('Buy $60');
-        
+
         // Complete
         $I->wait(5);
         $I->seeElement('#payee');
@@ -68,8 +68,5 @@ class ViewBuyCest
         $I->seeElement('#payee-id');
         $I->see('15');
         $I->see('We have charged your');
-
-
-
     }
 }

--- a/tests/acceptance/ViewShopCest.php
+++ b/tests/acceptance/ViewShopCest.php
@@ -10,12 +10,12 @@ class ViewShopCest
     {
         $I->amOnPage('/shop');
         $I->see('Example Templates');
-        
+    
         // Add first product
         $I->click('//button[@value=12]');
         $I->waitForElement('.flash');
         $I->see('Added The Last Knee-High to the cart.');
-
+    
         // Add second product
         $I->click('//button[@value=10]');
         $I->waitForElement('.flash');

--- a/tests/acceptance/ViewShopCest.php
+++ b/tests/acceptance/ViewShopCest.php
@@ -119,15 +119,15 @@ class ViewShopCest
         // Exit iframe
         $I->switchToIFrame();
     
-        $I->see('Pay $50.00');
-        $I->click('Pay $50.00');
+        $I->see('Pay $100.00');
+        $I->click('Pay $100.00');
     
         // Complete
         $I->wait(5);
     
         $I->see('Payee 1 Jane Example');
         $I->dontSee('Payee 2 Jane Example');
-        $I->see('Amount Paid: $50.00');
+        $I->see('Amount Paid: $100.00');
     
     }
     

--- a/tests/acceptance/ViewShopCest.php
+++ b/tests/acceptance/ViewShopCest.php
@@ -20,6 +20,126 @@ class ViewShopCest
         $I->click('//button[@value=10]');
         $I->waitForElement('.flash');
         $I->see('Added The Fleece Awakens to the cart.');
+    
+        $I->click('Checkout → Index');
+    
+        // /shop/checkout/email
+        $I->see('Let’s grab your email to get started');
+        $I->fillField('#email', 'hi@example.com');
+        $I->click('Continue');
+    
+        // /shop/checkout/register-signin
+        $I->click('Or, just continue as guest →');
+    
+        // /shop/checkout/addresses
+        $I->see('Shipping Address');
+        $I->click('Confirm addresses');
+    
+        // /shop/checkout/payment
+        $I->see('Payment');
+        $I->selectOption('Choose cart gateway or payment source:', ' Pay with: Stripe Payment Intents');
+    
+        $I->fillField('.card-holder-first-name', 'Test');
+        $I->fillField('.card-holder-last-name', 'MultipleToSamePayee');
+    
+        $I->waitForElement('.StripeElement');
+    
+        // https://stackoverflow.com/a/48123837/864799
+        $iframe_name = 'stripe-frame';
+        $I->executeJS("$('.__PrivateStripeElement iframe').attr('name', '$iframe_name')");
+        $I->switchToIFrame($iframe_name);
+    
+        // Inside iframe
+        $I->fillField('.CardNumberField-input-wrapper span input', '4242424242424242');
+        $I->fillField('.CardField-expiry span span input', '0325');
+        $I->fillField('.CardField-cvc span span input', '012');
+    
+        // Exit iframe
+        $I->switchToIFrame();
+    
+        $I->see('Pay $110.00');
+        $I->click('Pay $110.00');
+    
+        // Complete
+        $I->wait(5);
+        $I->see('Payee 1 Jane Example');
+        $I->see('Payee 2 Jane Example');
+        $I->see('Amount Paid: $110.00');
+    
+    }
+    
+    public function purchaseMultipleDifferentPayeesDontUseMarketplace(AcceptanceTester $I)
+    {
+        $I->amOnPage('/shop');
+        $I->see('Example Templates');
+    
+        // Add first product
+        $I->click('//button[@value=117]');
+        $I->waitForElement('.flash');
+        $I->see('Added Product With No Payee to the cart.');
+    
+        // Add second product
+        $I->click('//button[@value=10]');
+        $I->waitForElement('.flash');
+        $I->see('Added The Fleece Awakens to the cart.');
+    
+        $I->click('Checkout → Index');
+    
+        // /shop/checkout/email
+        $I->see('Let’s grab your email to get started');
+        $I->fillField('#email', 'hi@example.com');
+        $I->click('Continue');
+    
+        // /shop/checkout/register-signin
+        $I->click('Or, just continue as guest →');
+    
+        // /shop/checkout/addresses
+        $I->see('Shipping Address');
+        $I->click('Confirm addresses');
+    
+        // /shop/checkout/payment
+        $I->see('Payment');
+        $I->selectOption('Choose cart gateway or payment source:', ' Pay with: Stripe Payment Intents');
+    
+        $I->fillField('.card-holder-first-name', 'Test');
+        $I->fillField('.card-holder-last-name', 'NoPayeeSplit');
+    
+        $I->waitForElement('.StripeElement');
+    
+        // https://stackoverflow.com/a/48123837/864799
+        $iframe_name = 'stripe-frame';
+        $I->executeJS("$('.__PrivateStripeElement iframe').attr('name', '$iframe_name')");
+        $I->switchToIFrame($iframe_name);
+    
+        // Inside iframe
+        $I->fillField('.CardNumberField-input-wrapper span input', '4242424242424242');
+        $I->fillField('.CardField-expiry span span input', '0325');
+        $I->fillField('.CardField-cvc span span input', '012');
+    
+        // Exit iframe
+        $I->switchToIFrame();
+    
+        $I->see('Pay $50.00');
+        $I->click('Pay $50.00');
+    
+        // Complete
+        $I->wait(5);
+    
+        $I->see('Payee 1 Jane Example');
+        $I->dontSee('Payee 2 Jane Example');
+        $I->see('Amount Paid: $50.00');
+    
+    }
+    
+    public function purchaseOneDontUseMarketplace(AcceptanceTester $I)
+    {
+        $I->amOnPage('/shop');
+        $I->see('Example Templates');
+        
+        // Add first product, with no payee
+        $I->click('//button[@value=117]');
+        $I->waitForElement('.flash');
+        $I->see('Added Product With No Payee to the cart.');
         
         $I->click('Checkout → Index');
         
@@ -40,7 +160,7 @@ class ViewShopCest
         $I->selectOption('Choose cart gateway or payment source:', ' Pay with: Stripe Payment Intents');
 
         $I->fillField('.card-holder-first-name', 'Test');
-        $I->fillField('.card-holder-last-name', 'Lastname');
+        $I->fillField('.card-holder-last-name', 'RegularOrder');
 
         $I->waitForElement('.StripeElement');
 
@@ -57,14 +177,13 @@ class ViewShopCest
         // Exit iframe
         $I->switchToIFrame();
         
-        $I->see('Pay $110.00');
-        $I->click('Pay $110.00');
+        $I->see('Pay $50.00');
+        $I->click('Pay $50.00');
         
         // Complete
         $I->wait(5);
-        $I->see('Payee 1 Jane Example');
-        $I->see('Payee 2 Jane Example');
-        $I->see('Amount Paid: $110.00');
+        $I->dontSee('Payee 1');
+        $I->see('Amount Paid: $50.00');
 
     }
 }

--- a/tests/acceptance/ViewShopCest.php
+++ b/tests/acceptance/ViewShopCest.php
@@ -74,9 +74,9 @@ class ViewShopCest
         $I->see('Example Templates');
     
         // Add first product
-        $I->click('//button[@value=117]');
+        $I->click('//button[@value=165]');
         $I->waitForElement('.flash');
-        $I->see('Added Product With No Payee to the cart.');
+        $I->see('Added Product With No Payee 2 to the cart.');
     
         // Add second product
         $I->click('//button[@value=10]');
@@ -137,9 +137,9 @@ class ViewShopCest
         $I->see('Example Templates');
         
         // Add first product, with no payee
-        $I->click('//button[@value=117]');
+        $I->click('//button[@value=165]');
         $I->waitForElement('.flash');
-        $I->see('Added Product With No Payee to the cart.');
+        $I->see('Added Product With No Payee 2 to the cart.');
         
         $I->click('Checkout → Index');
         

--- a/tests/acceptance/ViewShopCest.php
+++ b/tests/acceptance/ViewShopCest.php
@@ -1,0 +1,70 @@
+<?php 
+
+class ViewShopCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function purchaseMultipleSamePayee(AcceptanceTester $I)
+    {
+        $I->amOnPage('/shop');
+        $I->see('Example Templates');
+        
+        // Add first product
+        $I->click('//button[@value=12]');
+        $I->waitForElement('.flash');
+        $I->see('Added The Last Knee-High to the cart.');
+
+        // Add second product
+        $I->click('//button[@value=10]');
+        $I->waitForElement('.flash');
+        $I->see('Added The Fleece Awakens to the cart.');
+        
+        $I->click('Checkout → Index');
+        
+        // /shop/checkout/email
+        $I->see('Let’s grab your email to get started');
+        $I->fillField('#email', 'hi@example.com');
+        $I->click('Continue');
+        
+        // /shop/checkout/register-signin
+        $I->click('Or, just continue as guest →');
+        
+        // /shop/checkout/addresses
+        $I->see('Shipping Address');
+        $I->click('Confirm addresses');
+
+        // /shop/checkout/payment
+        $I->see('Payment');
+        $I->selectOption('Choose cart gateway or payment source:', ' Pay with: Stripe Payment Intents');
+
+        $I->fillField('.card-holder-first-name', 'Test');
+        $I->fillField('.card-holder-last-name', 'Lastname');
+
+        $I->waitForElement('.StripeElement');
+
+        // https://stackoverflow.com/a/48123837/864799
+        $iframe_name = 'stripe-frame';
+        $I->executeJS("$('.__PrivateStripeElement iframe').attr('name', '$iframe_name')");
+        $I->switchToIFrame($iframe_name);
+
+        // Inside iframe
+        $I->fillField('.CardNumberField-input-wrapper span input', '4242424242424242');
+        $I->fillField('.CardField-expiry span span input', '0325');
+        $I->fillField('.CardField-cvc span span input', '012');
+
+        // Exit iframe
+        $I->switchToIFrame();
+        
+        $I->see('Pay $110.00');
+        $I->click('Pay $110.00');
+        
+        // Complete
+        $I->wait(5);
+        $I->see('Payee 1 Jane Example');
+        $I->see('Payee 2 Jane Example');
+        $I->see('Amount Paid: $110.00');
+
+    }
+}


### PR DESCRIPTION
Adds basic support for orders with multiple line items, when all line items will be using the same Payee.

When at least one line items has a different payee, the Marketplace plugin is not used, and the order is paid to the parent account (as in previous versions of the plugin).